### PR TITLE
Add devel

### DIFF
--- a/Formula/criterion.rb
+++ b/Formula/criterion.rb
@@ -8,16 +8,34 @@ class Criterion < Formula
   url  $repo, :tag => "v2.3.3"
   head $repo
 
+  devel do
+    url  $repo, :branch => "bleeding"
+    version "2.3.3"
+  end
+
   depends_on "nanomsg"
-  depends_on "cmake"    => :build
+  depends_on "cmake" => :build
+  depends_on "meson" => :build if build.devel?
 
   def install
-    system "cmake",
-        "-DCMAKE_BUILD_TYPE=RelWithDebInfo",
-        "-DCMAKE_INSTALL_PREFIX=#{prefix}",
-        "-DCMAKE_INSTALL_LIBDIR=lib",
-        "-DI18N=OFF",
-        "."
-    system "make install"
+    if build.devel?
+      system "meson",
+          "-Dbuildtype=debugoptimized",
+          "-Dprefix=#{prefix}",
+          "-Dlibdir=lib",
+          "-Di18n=disabled",
+          "-Dtests=false",
+          "-Dsamples=false",
+          "build"
+      system "ninja -C build install"
+    else
+      system "cmake",
+          "-DCMAKE_BUILD_TYPE=RelWithDebInfo",
+          "-DCMAKE_INSTALL_PREFIX=#{prefix}",
+          "-DCMAKE_INSTALL_LIBDIR=lib",
+          "-DI18N=OFF",
+          "."
+      system "make install"
+    end
   end
 end


### PR DESCRIPTION
This adds a devel section to the Criterion formula. It just points to the bleeding branch of the repository, and allows users to install whatever is there. Other than that, the actual logic of installing stable doesn't change.

To install devel, it would look something like:
```cmd
brew install --devel snaipe/soft/criterion
```

The main reason I am making this request is that there is no ppa package for Ubuntu Disco, so instead I want to use brew. This should let me work with the latest changes so I can use Meson.